### PR TITLE
Fix #178 (CSSClassApplier crashes when used with custom NS elements)

### DIFF
--- a/src/js/modules/rangy-cssclassapplier.js
+++ b/src/js/modules/rangy-cssclassapplier.js
@@ -20,6 +20,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
     var log = log4javascript.getLogger("rangy.classapplier");
 
     var defaultTagName = "span";
+    var defaultNamespace = "http://www.w3.org/1999/xhtml";
 
     function each(obj, func) {
         for (var i in obj) {
@@ -63,7 +64,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
     })();
 
     function sortClassName(className) {
-        return className.split(/\s+/).sort().join(" ");
+        return className && className.split(/\s+/).sort().join(" ");
     }
 
     function getSortedClassName(el) {
@@ -366,7 +367,8 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
     }
 
     function areElementsMergeable(el1, el2) {
-        return el1.tagName.toLowerCase() == el2.tagName.toLowerCase() &&
+        return el1.namespaceURI == el2.namespaceURI &&
+            el1.tagName.toLowerCase() == el2.tagName.toLowerCase() &&
             haveSameClasses(el1, el2) &&
             elementsHaveSameNonClassAttributes(el1, el2) &&
             getComputedStyleProperty(el1, "display") == "inline" &&
@@ -710,6 +712,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
             var parent = textNode.parentNode;
             if (parent.childNodes.length == 1 &&
                     this.useExistingElements &&
+                    parent.namespaceURI == defaultNamespace &&
                     contains(this.tagNames, parent.tagName.toLowerCase()) &&
                     elementHasProperties(parent, this.elementProperties)) {
 
@@ -723,7 +726,8 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
         },
 
         isRemovable: function(el) {
-            return el.tagName.toLowerCase() == this.elementTagName &&
+            return el.namespaceURI == defaultNamespace &&
+                el.tagName.toLowerCase() == this.elementTagName &&
                 getSortedClassName(el) == this.elementSortedClassName &&
                 elementHasProperties(el, this.elementProperties) &&
                 !elementHasNonClassAttributes(el, this.attrExceptions) &&

--- a/test/classappliertests.js
+++ b/test/classappliertests.js
@@ -747,6 +747,71 @@ xn.test.suite("Class Applier module tests", function(s) {
         t.assertEquals(range.endOffset, 2);
     });
 
+    s.test("Apply ignores non-HTML elements (issue #178)", function(t) {
+        var applier = rangy.createCssClassApplier("test");
+        var testEl = document.getElementById("test");
+        var customElement = document.createElementNS('my:custom:ns', 'span');
+        customElement.appendChild(document.createTextNode('b'));
+        testEl.appendChild(customElement);
+        var range = rangy.createRange();
+        range.selectNode(testEl);
+        applier.applyToRange(range);
+        t.assertEquals(testEl.childNodes.length, 1);
+        t.assertEquals(testEl.firstChild, customElement);
+        t.assertEquals(testEl.firstChild.childNodes.length, 1);
+        // Some browsers don't put a valid innerHTML on custom namespaced elements
+        t.assertEquals(testEl.firstChild.firstChild.outerHTML, '<span class="test">b</span>');
+    });
+
+    s.test("Unapply ignores non-HTML elements (issue #178)", function(t) {
+        var applier = rangy.createCssClassApplier("test");
+        var testEl = document.getElementById("test");
+        var customElement = document.createElementNS('my:custom:ns', 'span');
+        // Make the custom element look somewhat like a HTML element
+        customElement.setAttribute("class", "test");
+        customElement.appendChild(document.createTextNode('b'));
+        testEl.appendChild(customElement);
+        var range = rangy.createRange();
+        range.selectNode(testEl);
+        applier.undoToRange(range);
+        t.assertEquals(testEl.childNodes.length, 1);
+        t.assertEquals(testEl.firstChild, customElement);
+        t.assertEquals(testEl.firstChild.childNodes.length, 1);
+        t.assertEquals(testEl.firstChild.firstChild.nodeType, 3 /*Node.TEXT_NODE*/);
+        t.assertEquals(testEl.firstChild.firstChild.textContent, "b");
+    });
+
+    s.test("removeEmptyContainers ignores non-HTML elements (issue #178)", function(t) {
+        var applier = rangy.createCssClassApplier("test");
+        var testEl = document.getElementById("test");
+        var customElement = document.createElementNS('my:custom:ns', 'span');
+        // Make the custom element look somewhat like a HTML element
+        customElement.setAttribute("class", "test");
+        testEl.appendChild(customElement);
+        var range = rangy.createRange();
+        range.selectNode(testEl);
+        applier.applyToRange(range);
+        t.assertEquals(testEl.childNodes.length, 1);
+        t.assertEquals(testEl.firstChild, customElement);
+    });
+
+    s.test("Merging ignores non-HTML elements (issue #178)", function(t) {
+        var applier = rangy.createCssClassApplier("test");
+        var testEl = document.getElementById("test");
+        testEl.innerHTML = "a";
+        var customElement = document.createElementNS('my:custom:ns', 'span');
+        // Make the custom element look somewhat like a HTML element
+        customElement.setAttribute("class", "test");
+        customElement.appendChild(document.createTextNode('b'));
+        testEl.appendChild(customElement);
+        var range = rangy.createRange();
+        range.selectNode(testEl);
+        applier.applyToRange(range);
+        t.assertEquals(testEl.childNodes.length, 2);
+        t.assertEquals(testEl.childNodes[0].outerHTML, '<span class="test">a</span>');
+        t.assertEquals(testEl.childNodes[1], customElement);
+    });
+
     if (rangy.features.selectionSupportsMultipleRanges) {
         s.test("Undo to multiple ranges", function(t) {
             var testEl = document.getElementById("test");


### PR DESCRIPTION
The CSS class & className attributes are only available on HTML elements.
Cope with these variables being undefined.

In addition, only remove or merge elements that are in the HTML namespace.

This patch is public domain, so feel free to do with it as you will.
