### PR TITLE
Avoid calling getElementChecksum if not needed

### DIFF
--- a/src/js/modules/rangy-serializer.js
+++ b/src/js/modules/rangy-serializer.js
@@ -174,10 +174,13 @@ rangy.createModule("Serializer", ["WrappedSelection"], function(api, module) {
             rootNode = doc.documentElement;
         }
         var result = deserializeRegex.exec(serialized);
-        var checksum = result[4], rootNodeChecksum = getElementChecksum(rootNode);
-        if (checksum && checksum !== getElementChecksum(rootNode)) {
-            throw module.createError("deserializeRange(): checksums of serialized range root node (" + checksum +
+        var checksum = result[4];
+        if (checksum) {
+            var rootNodeChecksum = getElementChecksum(rootNode);
+            if (checksum !== rootNodeChecksum) {
+                throw module.createError("deserializeRange(): checksums of serialized range root node (" + checksum +
                     ") and target root node (" + rootNodeChecksum + ") do not match");
+            }
         }
         var start = deserializePosition(result[1], rootNode, doc), end = deserializePosition(result[2], rootNode, doc);
         var range = api.createRange(doc);


### PR DESCRIPTION
If there's no checksum in `serialized`, there's no need to call `getElementChecksum(rootNode)`.
