### PR TITLE
Auto-initialise rangy even if window load event has already been fired

### DIFF
--- a/src/js/core/core.js
+++ b/src/js/core/core.js
@@ -419,7 +419,9 @@
     var docReady = false;
 
     var loadHandler = function(e) {
-        log.info("loadHandler, event is " + e.type);
+        if (e) {
+            log.info("loadHandler, event is " + e.type);
+        }
         if (!docReady) {
             docReady = true;
             if (!api.initialized && api.config.autoInitialize) {
@@ -438,12 +440,17 @@
         return;
     }
 
-    if (isHostMethod(document, "addEventListener")) {
-        document.addEventListener("DOMContentLoaded", loadHandler, false);
-    }
+    // Test whether the document has already been loaded
+    if (document.readyState === "complete") {
+        loadHandler()
+    } else {
+        if (isHostMethod(document, "addEventListener")) {
+            document.addEventListener("DOMContentLoaded", loadHandler, false);
+        }
 
-    // Add a fallback in case the DOMContentLoaded event isn't supported
-    addListener(window, "load", loadHandler);
+        // Add a fallback in case the DOMContentLoaded event isn't supported
+        addListener(window, "load", loadHandler);
+    }
 
     /*----------------------------------------------------------------------------------------------------------------*/
     


### PR DESCRIPTION
Fixes an issue where rangy doesn't auto-initialise if loaded _after_ the window load event has fired (e.g., when loaded via require.js).

The document readyState seems to have been around for a while (http://msdn.microsoft.com/en-au/library/ie/ms534359%28v=vs.85%29.aspx), so I don't believe this has any backwards compat issues with older IE versions. Worst case, if the property doesn't exist or has an odd string, the code will fall back to waiting for the events (as it does currently).
