### PR TITLE
Bug fix and unit test for edge case failure in findText() when using a r...

### DIFF
--- a/src/modules/rangy-textrange.js
+++ b/src/modules/rangy-textrange.js
@@ -1540,10 +1540,10 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
             if (isRegex) {
                 result = searchTerm.exec(text);
                 if (result) {
+                    matchStartIndex = result.index;
+                    matchEndIndex = matchStartIndex + result[0].length;
                     if (insideRegexMatch) {
                         // Check whether the match is now over
-                        matchStartIndex = result.index;
-                        matchEndIndex = matchStartIndex + result[0].length;
                         if ((!backward && matchEndIndex < text.length) || (backward && matchStartIndex > 0)) {
                             returnValue = handleMatch(matchStartIndex, matchEndIndex);
                             break;

--- a/test/textrangetests.js
+++ b/test/textrangetests.js
@@ -1047,6 +1047,22 @@ xn.test.suite("Text Range module tests", function(s) {
         testRangeBoundaries(t, range, textNode, 14, textNode, 17);
     });
 
+    s.test("findText regex at end of scope", function(t) {
+        t.el.innerHTML = 'One Two three';
+        var textNode = t.el.firstChild;
+        var range = rangy.createRange();
+        range.collapseToPoint(textNode, 0);
+
+        var scopeRange = rangy.createRange();
+        scopeRange.selectNodeContents(t.el);
+        var options = {
+            withinRange: scopeRange
+        };
+
+        t.assert(range.findText(/three/, options));
+        testRangeBoundaries(t, range, textNode, 8, textNode, 13);
+    });
+
     s.test("createWordIterator", function(t) {
         t.el.innerHTML = 'One two three; four';
 


### PR DESCRIPTION
The new unit test throws an exception without the change to `rangy-textrange.js` and I traced it back to the `handleMatch()` call on line 1564 being made when `matchStartIndex` is undefined.

If my understanding of the code is correct, we should be setting `matchStartIndex` and `matchEndIndex` anytime we get a match, rather than only when we are already in a match.
