### PR TITLE
Add support for the Element.classList interface

### DIFF
--- a/src/modules/rangy-classapplier.js
+++ b/src/modules/rangy-classapplier.js
@@ -39,11 +39,25 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
     }
 
     function hasClass(el, className) {
+        if (el.classList) {
+            var parts = className.split(/\s+/g);
+            while (parts[0]) {
+                if (!el.classList.contains(parts.shift())) {
+                    return false;
+                }
+            }
+            return true;
+        }
         return el.className && new RegExp("(?:^|\\s)" + className + "(?:\\s|$)").test(el.className);
     }
 
     function addClass(el, className) {
-        if (el.className) {
+        if (el.classList) {
+            var parts = className.split(/\s+/g);
+            while (parts[0]) {
+                el.classList.add(parts.shift());
+            }
+        } else if (el.className) {
             if (!hasClass(el, className)) {
                 el.className += " " + className;
             }
@@ -58,7 +72,12 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
         }
 
         return function(el, className) {
-            if (el.className) {
+            if (el.classList) {
+                var parts = className.split(/\s+/g);
+                while (parts[0]) {
+                    el.classList.remove(parts.shift());
+                }
+            } else if (el.className) {
                 el.className = el.className.replace(new RegExp("(^|\\s)" + className + "(\\s|$)"), replacer);
             }
         };


### PR DESCRIPTION
The classList interface has been available since IE10, and is quite widely available on modern browsers. Using this provides a hefty performance increase when highlighting large documents.

My own anecdotal evidence for the performance impact is that the processing time spent within rangy on a private application has dropped from 3.2s to 1.3s with just this patch.
# Update

I had to adjust the original patch as add/has/removeClass functions all can take white-space separated lists of classes. Fortunately, accounting for this, using the classList interface is still significantly quicker on large documents.
