### PR TITLE
Reduce number of intersection checks when undoing highlighting

### DIFF
--- a/src/modules/rangy-classapplier.js
+++ b/src/modules/rangy-classapplier.js
@@ -796,6 +796,24 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
                     ancestorWithClass = splitNodeAt(ancestorWithClass, range.startContainer, range.startOffset, positionsToPreserve);
                 }
             }
+
+            log.info("isRemovable", this.isRemovable(ancestorWithClass), dom.inspectNode(ancestorWithClass), "'" + ancestorWithClass.innerHTML + "'", "'" + ancestorWithClass.parentNode.innerHTML + "'");
+            if (this.isRemovable(ancestorWithClass)) {
+                replaceWithOwnChildrenPreservingPositions(ancestorWithClass, positionsToPreserve);
+            } else {
+                removeClass(ancestorWithClass, this.className);
+            }
+        },
+
+        splitAncestorWithClass: function(container, offset, positionsToPreserve) {
+            var ancestorWithClass = this.getSelfOrAncestorWithClass(container);
+            if (ancestorWithClass) {
+                log.info("splitAncestorWithClass", dom.inspectNode(ancestorWithClass), dom.inspectNode(container), offset);
+                splitNodeAt(ancestorWithClass, container, offset, positionsToPreserve);
+            }
+        },
+
+        undoToAncestor: function(ancestorWithClass, positionsToPreserve) {
             log.info("isRemovable", this.isRemovable(ancestorWithClass), dom.inspectNode(ancestorWithClass), "'" + ancestorWithClass.innerHTML + "'", "'" + ancestorWithClass.parentNode.innerHTML + "'");
             if (this.isRemovable(ancestorWithClass)) {
                 replaceWithOwnChildrenPreservingPositions(ancestorWithClass, positionsToPreserve);
@@ -878,11 +896,13 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
             var lastTextNode = textNodes[textNodes.length - 1];
 
             if (textNodes.length) {
+                this.splitAncestorWithClass(range.endContainer, range.endOffset, positionsToPreserve);
+                this.splitAncestorWithClass(range.startContainer, range.startOffset, positionsToPreserve);
                 for (var i = 0, len = textNodes.length; i < len; ++i) {
                     textNode = textNodes[i];
                     ancestorWithClass = this.getSelfOrAncestorWithClass(textNode);
                     if (ancestorWithClass && this.isModifiable(textNode)) {
-                        this.undoToTextNode(textNode, range, ancestorWithClass, positionsToPreserve);
+                        this.undoToAncestor(ancestorWithClass, positionsToPreserve);
                     }
 
                     // Ensure the range is still valid

--- a/src/modules/rangy-classapplier.js
+++ b/src/modules/rangy-classapplier.js
@@ -904,10 +904,9 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
                     if (ancestorWithClass && this.isModifiable(textNode)) {
                         this.undoToAncestor(ancestorWithClass, positionsToPreserve);
                     }
-
-                    // Ensure the range is still valid
-                    range.setStartAndEnd(textNodes[0], 0, lastTextNode, lastTextNode.length);
                 }
+                // Ensure the range is still valid
+                range.setStartAndEnd(textNodes[0], 0, lastTextNode, lastTextNode.length);
 
                 log.info("Undo set range to '" + textNodes[0].data + "', '" + textNode.data + "'");
 


### PR DESCRIPTION
Intersection checks become very expensive when updating the highlight on a large document. Intersections can only occur at the start and end of a range, allowing only two of these to be necessary.

Note, I've left the existing undoToTextNode function behind... please let me know if you want that removed as well!

More anecdotal evidence on my own rigs show in that one particular set of calls have dropped from ~60s to ~15s (it's a massive document I'm highlighting... would take up 1000 A4 pages if printed...).