### PR TITLE
Correct container re-use when highlighter is applying a base className

### DIFF
--- a/src/modules/rangy-classapplier.js
+++ b/src/modules/rangy-classapplier.js
@@ -716,7 +716,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
             var applier = this;
             return each(props, function(p, propValue) {
                 if (p == "className") {
-                    return sortClassName(el.className) == applier.elementSortedClassName;
+                    return hasClass(el, propValue);
                 } else if (typeof propValue == "object") {
                     if (!applier.elementHasProperties(el[p], propValue)) {
                         return false;

--- a/test/classappliertests.js
+++ b/test/classappliertests.js
@@ -535,6 +535,32 @@ xn.test.suite("Class Applier module tests", function(s) {
         t.assertEquals('t[es]t', htmlAndRangeToString(testEl, range));
     });
 
+    s.test("Test adding extra class with overlapping containers", function(t) {
+        var applier = rangy.createClassApplier("c1", { elementProperties: { "className": "extra" } });
+        var applier2 = rangy.createClassApplier("c2", { elementProperties: { "className": "extra" } });
+
+        var testEl = document.getElementById("test");
+        var range = createRangeInHtml(testEl, 't[es]t');
+        applier.applyToRange(range);
+        applier2.applyToRange(range);
+        t.assertEquals('t<span class="c1 c2 extra">[es]</span>t', htmlAndRangeToString(testEl, range));
+    });
+
+    s.test("Test toggling extra class with overlapping containers", function(t) {
+        var applier = rangy.createClassApplier("c1", { elementProperties: { "className": "extra" } });
+        var applier2 = rangy.createClassApplier("c2", { elementProperties: { "className": "extra" } });
+
+        var testEl = document.getElementById("test");
+        var range = createRangeInHtml(testEl, 't[es]t');
+        applier.applyToRange(range);
+        applier2.applyToRange(range);
+        applier2.undoToRange(range);
+        t.assertEquals('t<span class="c1 extra">[es]</span>t', htmlAndRangeToString(testEl, range));
+
+        applier.undoToRange(range);
+        t.assertEquals('t[es]t', htmlAndRangeToString(testEl, range));
+    });
+
     s.test("Test range after two toggles", function(t) {
         var applier1 = rangy.createClassApplier("c1");
 


### PR DESCRIPTION
Highlighting was not detecting a reusable container if an extra class name was applied via the elementProperties configuration object. This is because the container comparison required the reusable container have *all* the classes... including the one about to be applied.

Restrict this particular check to only require class names to match the supplied elementProperties config setting.