### PR TITLE
Fix wordOptions in findText()

### DIFF
--- a/src/modules/rangy-textrange.js
+++ b/src/modules/rangy-textrange.js
@@ -1489,7 +1489,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
     function isWholeWord(startPos, endPos, wordOptions) {
         var range = api.createRange(startPos.node);
         range.setStartAndEnd(startPos.node, startPos.offset, endPos.node, endPos.offset);
-        var returnVal = !range.expand("word", wordOptions);
+        var returnVal = !range.expand("word", { wordOptions: wordOptions });
         return returnVal;
     }
 


### PR DESCRIPTION
findText() wasn't respecting wordOptions properly because isWholeWord was passing them through as the top-level options, not as the word-options sub-hash.
