### PR TITLE
make xhtml compliant

### DIFF
--- a/lib/rangy-textrange.js
+++ b/lib/rangy-textrange.js
@@ -114,7 +114,7 @@
             sel.setStart(p.firstChild, 0);
             trailingSpaceInBlockCollapses = ("" + sel).length == 1;
 
-            el.innerHTML = "1 <br>";
+            el.innerHTML = "1 <br />";
             sel.collapse(el, 2);
             sel.setStart(el.firstChild, 0);
             trailingSpaceBeforeBrCollapses = ("" + sel).length == 1;

--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -320,7 +320,7 @@
         var el = document.createElement("b");
         el.innerHTML = "1";
         var textNode = el.firstChild;
-        el.innerHTML = "<br>";
+        el.innerHTML = "<br />";
         crashyTextNodes = isBrokenNode(textNode);
 
         api.features.crashyTextNodes = crashyTextNodes;


### PR DESCRIPTION
To fix 
`Failed to set the 'innerHTML' property on 'Element': The provided markup is invalid XML, and therefore cannot be inserted into an XML document.
`

Which is the reason of a `DOMUtil` failed error
