### PR TITLE
Adding an explicit link to the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Rangy now has AMD support.
 ## NPM
 
 There is an official Rangy module on NPM called [`rangy`](https://www.npmjs.org/package/rangy).
+
+## Documentation
+
+View [the documentation in the wiki](https://github.com/timdown/rangy/wiki). 


### PR DESCRIPTION
I had no idea the wiki was there until i saw a note on *google code*.