### PR TITLE
Added config option for CommonJS syntax

### DIFF
--- a/lib/rangy-core.js
+++ b/lib/rangy-core.js
@@ -14,12 +14,14 @@
         define(factory);
     } else if (typeof module != "undefined" && typeof exports == "object") {
         // Node/CommonJS style
-        module.exports = factory();
+        module.exports = function(config){
+            return factory(config);
+        };
     } else {
         // No AMD or CommonJS support so we place Rangy in (probably) the global variable
         root.rangy = factory();
     }
-})(function() {
+})(function(config) {
 
     var OBJECT = "object", FUNCTION = "function", UNDEFINED = "undefined";
 
@@ -117,9 +119,9 @@
         features: {},
         modules: modules,
         config: {
-            alertOnFail: true,
-            alertOnWarn: false,
-            preferTextRange: false,
+            alertOnFail: (config && config.alertOnFail) ? config.alertOnFail : true,
+            alertOnWarn: (config && config.alertOnWarn) ? config.alertOnWarn : false,
+            preferTextRange: (config && config.preferTextRange) ? config.preferTextRange : false,
             autoInitialize: (typeof rangyAutoInitialize == UNDEFINED) ? true : rangyAutoInitialize
         }
     };


### PR DESCRIPTION
This is controversial. Currently, passing a configuration by using
`rangy.config.alertOnFail = false` after `require('rangy')` does not work
in all environments, I believe because it is async and it isn't able to
access the function as it is wrapped in an IIFE. In order to fix this,
when rangy is initialized, the config has to be loaded in immediately.

This isn't possible with the current syntax, as you can't load in parameters.
After a lot of fiddling around, the best I could come up with was this
solution. However, it is a breaking change - all implementations using require
and CommonJS will have to use this syntax:

```js
var rangy = require('rangy')()
```

To set a config, you would do this:

```js
var rangy = require('rangy')({'alertOnFail': true})
```

I couldn't find a way around this. This solution works for me, closes #280.