### PR TITLE
fix safari and chrome range.text() bug. move selection to node offset=0 ...

### DIFF
--- a/lib/rangy-textrange.js
+++ b/lib/rangy-textrange.js
@@ -1674,10 +1674,10 @@
                     var rangeBetween = this.cloneRange();
                     var startIndex, endIndex;
                     if (rangeStartsBeforeNode) {
-                        rangeBetween.setStartAndEnd(this.startContainer, this.startOffset, parent, nodeIndex);
+                        rangeBetween.setStartAndEnd(this.startContainer, this.startOffset, containerNode, 0);
                         startIndex = -rangeBetween.text(characterOptions).length;
                     } else {
-                        rangeBetween.setStartAndEnd(parent, nodeIndex, this.startContainer, this.startOffset);
+                        rangeBetween.setStartAndEnd(containerNode, 0, this.startContainer, this.startOffset);
                         startIndex = rangeBetween.text(characterOptions).length;
                     }
                     endIndex = startIndex + this.text(characterOptions).length;


### PR DESCRIPTION
...instead of move selection to node.parentNode.nthChild.

This fixed the issue #286 