### PR TITLE
Do not apply class to contents of button tag

### DIFF
--- a/src/modules/rangy-classapplier.js
+++ b/src/modules/rangy-classapplier.js
@@ -125,7 +125,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
 
     function canTextBeStyled(textNode) {
         var parent = textNode.parentNode;
-        return (parent && parent.nodeType == 1 && !/^(textarea|style|script|select|iframe)$/i.test(parent.nodeName));
+        return (parent && parent.nodeType == 1 && !/^(textarea|style|script|select|iframe|button)$/i.test(parent.nodeName));
     }
 
     function movePosition(position, oldParent, oldIndex, newParent, newIndex) {


### PR DESCRIPTION
Contents of `button` tags should not be altered with `ClassApplier` module.