### PR TITLE
appendChild not aware of void elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "rangy",
     "description": "A cross-browser DOM range and selection library",
-    "version": "1.3.1-dev",
+    "version": "1.3.2-dev",
     "author": {
         "name": "Tim Down",
         "email": "tim@timdown.co.uk",

--- a/src/core/domrange.js
+++ b/src/core/domrange.js
@@ -57,7 +57,7 @@
             if (canAppendChild(n)) {
                 n.appendChild(node);
             } else {
-                dom.insertBefore(node, n);
+                n.parentNode.insertBefore(node, n);
             }
         } else {
             n.insertBefore(node, n.childNodes[o]);

--- a/src/core/domrange.js
+++ b/src/core/domrange.js
@@ -5,7 +5,7 @@
     var util = api.util;
     var DomPosition = dom.DomPosition;
     var DOMException = api.DOMException;
-
+    var voidElements = ["area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr"];
     var isCharacterDataNode = dom.isCharacterDataNode;
     var getNodeIndex = dom.getNodeIndex;
     var isOrIsAncestorOf = dom.isOrIsAncestorOf;
@@ -54,7 +54,11 @@
                 n.parentNode.insertBefore(node, o == 0 ? n : splitDataNode(n, o));
             }
         } else if (o >= n.childNodes.length) {
-            n.appendChild(node);
+            if (canAppendChild(n)) {
+                n.appendChild(node);
+            } else {
+                dom.insertBefore(node, n);
+            }
         } else {
             n.insertBefore(node, n.childNodes[o]);
         }
@@ -73,6 +77,12 @@
             endComparison = comparePoints(rangeA.endContainer, rangeA.endOffset, rangeB.startContainer, rangeB.startOffset);
 
         return touchingIsIntersecting ? startComparison <= 0 && endComparison >= 0 : startComparison < 0 && endComparison > 0;
+    }
+
+    function canAppendChild(element) {
+        var nodeName = element.tagName.toLowerCase();
+
+        return voidElements.indexOf(nodeName) === -1;
     }
 
     function cloneSubtree(iterator) {


### PR DESCRIPTION
At present, calling insertNodeAtPosition where n is a void element (e.g., <br>) causes the element to be appended as a child element, which results (potentially) in invalid nested elements.

I have added an array containing all the void elements as per http://www.w3.org/TR/html-markup/syntax.html#void-elements, and a function canAppendChild(element) to avoid this issue. 