### PR TITLE
Handle more than one class in ClassApplier::addClass Method

### DIFF
--- a/lib/rangy-classapplier.js
+++ b/lib/rangy-classapplier.js
@@ -66,7 +66,11 @@
         }
 
         function addClass(el, className) {
-            if (typeof el.classList == "object") {
+            if (typeof className === "object") {
+                className.forEach(function(name) { 
+                    addClass(el, name);
+                });
+            } else if (typeof el.classList == "object") {
                 el.classList.add(className);
             } else {
                 var classNameSupported = (typeof el.className == "string");


### PR DESCRIPTION
I'm attempting to use rangy to apply highlights and notes to a document reader application. While the library is really good at applying the highlights, I need to add several different classes to each highlight. I can't seem to find any means of doing that with the ClassApplier as-is. This change allows the caller to pass an array of classes to a ClassApplier and thereby add as many classes as needed.

My apologies if this isn't the right process to make such a suggestion.