### PR TITLE
speedup normalizeIgnoredCharacters when no chars are ignored

### DIFF
--- a/src/modules/rangy-textrange.js
+++ b/src/modules/rangy-textrange.js
@@ -188,6 +188,9 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
         // Check if character is ignored
         var ignoredChars = ignoredCharacters || "";
 
+        if (ignoredCharacters === "")
+            return ignoredCharacters
+
         // Normalize ignored characters into a string consisting of characters in ascending order of character code
         var ignoredCharsArray = (typeof ignoredChars == "string") ? ignoredChars.split("") : ignoredChars;
         ignoredCharsArray.sort(function(char1, char2) {


### PR DESCRIPTION
While investigating https://github.com/timdown/rangy/issues/330, I noticed a quick optimization for `normalizeIgnoredCharacters` (~7% CPU usage in Chrome profiler).  We could simply `return "" if ignoredChars === ""`, as that is what will be returned anyways if the function were to continue.  Quick benchmarks states that it speeds up the function by > 50x in this case, with no impact on other cases.

Here is the benchmark info:
https://jsperf.com/rangy-normalizeignoredcharacters