### PR TITLE
make the rangy.shim(iframeWin) works

### DIFF
--- a/src/core/wrappedrange.js
+++ b/src/core/wrappedrange.js
@@ -613,6 +613,6 @@
                 return api.createRange(doc);
             };
         }
-        doc = win = null;
+        win = null;
     });
 });

--- a/src/core/wrappedselection.js
+++ b/src/core/wrappedselection.js
@@ -1021,6 +1021,5 @@
                 return getSelection(win);
             };
         }
-        win = null;
     });
 });


### PR DESCRIPTION
I want to use rangy.shim for a iframe window to make At.js work fine under IE6 with a contentEditable iframe.

with code like below

    rangy.shim(ifr.contentWindow);

but when I make a Breakpoints at the code below

    api.addShimListener(function(win) {
        if (typeof win.getSelection == "undefined") {
            win.getSelection = function() {
                return getSelection(win);   // at here the win is null
            };
        }
        win = null;   // set the win to null will make the returned getSelection can't get the real win
    });


so I delete the `win = null;`

and also the `doc.createRange`
