### PR TITLE
Add Meteor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ The latest source code and releases are on [GitHub](../../releases).
 
 There is now an official Rangy package for Bower with Rangy 1.2 and 1.3 versions, called `rangy`.
 
+# Meteor
+
+There is now an official Rangy package for Meteor, it exports `rangy` on client.
+
+```sh
+meteor add timdown:rangy
+```
+
 ## AMD
 
 Rangy 1.3 has AMD support.
@@ -21,4 +29,4 @@ There is an official Rangy module on NPM called [`rangy`](https://www.npmjs.org/
 
 ## Documentation
 
-Documentation is in [the GitHub wiki](https://github.com/timdown/rangy/wiki). 
+Documentation is in [the GitHub wiki](https://github.com/timdown/rangy/wiki).

--- a/package.js
+++ b/package.js
@@ -1,0 +1,15 @@
+Package.describe({
+	documentation: 'README.md',
+	git: 'https://github.com/timdown/rangy.git',
+	name: 'timdown:rangy',
+	summary: 'A cross-browser JavaScript range and selection library.',
+	version: '1.3.1-dev'
+});
+
+Package.onUse(function(api) {
+	api.versionsFrom('1.0');
+
+	api.addFiles('lib/rangy-core.js', 'client');
+
+	api.export('rangy', 'client');
+});

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -9,7 +9,10 @@
  */
 
 (function(factory, root) {
-    if (typeof define == "function" && define.amd) {
+    if (Package) {
+        // Meteor, can be removed once Meteor support modules
+        rangy = factory();
+    } else if (typeof define == "function" && define.amd) {
         // AMD. Register as an anonymous module.
         define(factory);
     } else if (typeof module != "undefined" && typeof exports == "object") {


### PR DESCRIPTION
This PR together with a one-time setup at http://autopublish.meteor.com will give you automatic publishing of the package to atmosphere when you tag new releases.

This is what you need to do.
1. `meteor admin maintainers timdown:rangy --add publishbot` from cli
2. Go to http://autopublish.meteor.com, login with your meteor developer account
3. Go to the repository list and toggle `webhook` and `autopublish`
4. Merge this PR.

Don't forget to bump version in `package.js` before tagging a new release.

The next time you tag a new release the the new version should automagically
be published to atmosphere.

I've only included `rangy-core.js` in the `package.js` file. This is because the other files are
plugins/addons if I've got it correctly, and I think these could be released as separate packages
`timdown:rangy-\<plugin\>`, depeding on `timdown:rangy`.

P.S. I didn't wanna update the built files as I'm not familiar with the project setup in-depth.
