### PR TITLE
Added Element relative Highlighter Range.

### DIFF
--- a/demos/highlighter_text_range.html
+++ b/demos/highlighter_text_range.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<!--[if lte IE 6]><html class="ie6"><!--[if gt IE 8]><!--><html><!--<![endif]-->
+<head>
+    <title>Rangy Highlighter Module Demo</title>
+    <link href="demo.css" rel="stylesheet" type="text/css">
+    <style type="text/css">
+        .highlight {
+            background-color: yellow;
+        }
+
+        .note {
+            background-color: limegreen;
+        }
+
+        #summary {
+            border: dotted orange 1px;
+        }
+    </style>
+    <script type="text/javascript" src="../lib/rangy-core.js"></script>
+    <script type="text/javascript" src="../lib/rangy-textrange.js"></script>
+    <script type="text/javascript" src="../lib/rangy-classapplier.js"></script>
+    <script type="text/javascript" src="../lib/rangy-highlighter.js"></script>
+    <script type="text/javascript">
+        function gEBI(id) {
+            return document.getElementById(id);
+        }
+        var serializedHighlights = decodeURIComponent(window.location.search.slice(window.location.search.indexOf("=") + 1));
+        var highlighter;
+
+        var initialDoc;
+
+        window.onload = function() {
+            rangy.init();
+
+            highlighter = rangy.createHighlighter(document.getElementById("content"), "TextRange");
+
+            highlighter.addClassApplier(rangy.createClassApplier("highlight", {
+                ignoreWhiteSpace: true,
+                tagNames: ["span", "a"]
+            }));
+
+            highlighter.addClassApplier(rangy.createClassApplier("note", {
+                ignoreWhiteSpace: true,
+                elementTagName: "a",
+                elementProperties: {
+                    href: "#",
+                    onclick: function() {
+                        var highlight = highlighter.getHighlightForElement(this);
+                        if (window.confirm("Delete this note (ID " + highlight.id + ")?")) {
+                            highlighter.removeHighlights( [highlight] );
+                        }
+                        return false;
+                    }
+                }
+            }));
+
+
+            if (serializedHighlights) {
+                highlighter.deserialize(serializedHighlights);
+            }
+        };
+
+
+        function highlightSelectedText() {
+            highlighter.highlightSelection("highlight");
+        }
+
+        function noteSelectedText() {
+            highlighter.highlightSelection("note");
+        }
+
+        function removeHighlightFromSelectedText() {
+            highlighter.unhighlightSelection();
+        }
+
+        function highlightScopedSelectedText() {
+            highlighter.highlightSelection("highlight", { containerElementId: "summary" });
+        }
+
+        function noteScopedSelectedText() {
+            highlighter.highlightSelection("note", { containerElementId: "summary" });
+        }
+
+        function reloadPage(button) {
+            button.form.elements["serializedHighlights"].value = highlighter.serialize();
+            button.form.submit();
+        }
+
+    </script>
+</head>
+<body>
+<div id="buttons">
+    <h3>Highlighter</h3>
+    <p>Make a selection in the document and use the buttons below to highlight and unhighlight.</p>
+    <input type="button" ontouchstart="highlightSelectedText();" onclick="highlightSelectedText();" value="Highlight selection">
+    <input type="button" ontouchstart="noteSelectedText();" onclick="noteSelectedText();" value="Add note to selection">
+    <input type="button" ontouchstart="removeHighlightFromSelectedText();" onclick="removeHighlightFromSelectedText();" value="Remove highlights from selection">
+    <br>
+    <input type="button" ontouchstart="highlightScopedSelectedText();" onclick="highlightScopedSelectedText();" value="Highlight within outlined paragraph">
+    <input type="button" ontouchstart="noteScopedSelectedText();" onclick="noteScopedSelectedText();" value="Annotate selection within outlined paragraph">
+
+    <h3>Preserving highlights between page requests</h3>
+    <form action="highlighter_text_range.html" method="get">
+        Highlights can be preserved between page requests. Press the following button to reload the page with the
+        highlights preserved:
+        <br>
+        <input type="hidden" name="serializedHighlights" value="">
+        <input type="button" value="Reload" onclick="reloadPage(this)">
+    </form>
+</div>
+
+<div id="content">
+    <h1>Rangy Highlighter Module Demo</h1>
+    <p id="intro">
+        Please use your mouse and/or keyboard to make selections from the sample content below and use the buttons
+        on the left hand size to create and remove highlights.
+    </p>
+    <p id="summary">
+        <b>Association football</b> is a sport played between two teams. It is usually called <b>football</b>, but in
+        some countries, such as the United States, it is called <b>soccer</b>. In
+        <a href="http://simple.wikipedia.org/wiki/Japan">Japan</a>, New Zealand, South Africa, Australia, Canada and
+        Republic of Ireland, both words are commonly used.
+    </p>
+    <p>
+        Each team has 11 players on the field. One of these players is the <i>goalkeeper</i>, and the other ten are
+        known as <i>"outfield players."</i> The game is played by <b>kicking a ball into the opponent's goal</b>. A
+        match has 90 minutes of play, with a break of 15 minutes in the middle. The break in the middle is called
+        half-time.
+    </p>
+    <h2>Competitions</h2>
+    <p>
+        There are many competitions for football, for both football clubs and countries. Football clubs usually play
+        other teams in their own country, with a few exceptions. <b>Cardiff City F.C.</b> from Wales for example, play
+        in the English leagues and in the English FA Cup.
+    </p>
+    <h2>Who plays football <span class="smaller">(this section is in pre-formatted text)</span></h2>
+		<pre>
+Football is the world's most popular sport. It is played in more
+countries than any other game. In fact, FIFA (the Federation
+Internationale de Football Association) has more members than the
+United Nations.
+
+It is played by both males and females.
+
+
+</pre>
+</div>
+
+<p class="small">
+    Text adapted from <a href="http://simple.wikipedia.org/wiki/Association_football">Simple Wikipedia page on
+    Association Football</a>, licensed under the
+    <a href="http://simple.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License">Creative
+        Commons Attribution/Share-Alike License</a>.
+</p>
+</body>
+</html>

--- a/lib/rangy-classapplier.js
+++ b/lib/rangy-classapplier.js
@@ -7,10 +7,10 @@
  *
  * Depends on Rangy core.
  *
- * Copyright 2015, Tim Down
+ * Copyright 2016, Tim Down
  * Licensed under the MIT license.
  * Version: 1.3.1-dev
- * Build date: 20 May 2015
+ * Build date: 15 January 2016
  */
 (function(factory, root) {
     if (typeof define == "function" && define.amd) {
@@ -698,13 +698,10 @@
             // Normalizes nodes after applying a class to a Range.
             postApply: function(textNodes, range, positionsToPreserve, isUndo) {
                 var firstNode = textNodes[0], lastNode = textNodes[textNodes.length - 1];
-
                 var merges = [], currentMerge;
-
                 var rangeStartNode = firstNode, rangeEndNode = lastNode;
                 var rangeStartOffset = 0, rangeEndOffset = lastNode.length;
-
-                var textNode, precedingTextNode;
+                var precedingTextNode;
 
                 // Check for every required merge and create a Merge object for each
                 forEach(textNodes, function(textNode) {
@@ -741,7 +738,7 @@
 
                 // Apply the merges
                 if (merges.length) {
-                    for (i = 0, len = merges.length; i < len; ++i) {
+                    for (var i = 0, len = merges.length; i < len; ++i) {
                         merges[i].doMerge(positionsToPreserve);
                     }
 

--- a/lib/rangy-core.js
+++ b/lib/rangy-core.js
@@ -2,10 +2,10 @@
  * Rangy, a cross-browser JavaScript range and selection library
  * https://github.com/timdown/rangy
  *
- * Copyright 2015, Tim Down
+ * Copyright 2016, Tim Down
  * Licensed under the MIT license.
  * Version: 1.3.1-dev
- * Build date: 20 May 2015
+ * Build date: 15 January 2016
  */
 
 (function(factory, root) {
@@ -222,7 +222,7 @@
     })();
 
     // Very simple event handler wrapper function that doesn't attempt to solve issues such as "this" handling or
-    // normalization of event properties
+    // normalization of event properties because we don't need this.
     var addListener;
     if (isBrowser) {
         if (isHostMethod(document, "addEventListener")) {
@@ -1303,6 +1303,7 @@
         var getDocumentOrFragmentContainer = createAncestorFinder( [9, 11] );
         var getReadonlyAncestor = createAncestorFinder(readonlyNodeTypes);
         var getDocTypeNotationEntityAncestor = createAncestorFinder( [6, 10, 12] );
+        var getElementAncestor = createAncestorFinder( [1] );
 
         function assertNoDocTypeNotationEntityAncestor(node, allowSelf) {
             if (getDocTypeNotationEntityAncestor(node, allowSelf)) {
@@ -1365,7 +1366,7 @@
         var htmlParsingConforms = false;
         try {
             styleEl.innerHTML = "<b>x</b>";
-            htmlParsingConforms = (styleEl.firstChild.nodeType == 3); // Opera incorrectly creates an element node
+            htmlParsingConforms = (styleEl.firstChild.nodeType == 3); // Pre-Blink Opera incorrectly creates an element node
         } catch (e) {
             // IE 6 and 7 throw
         }
@@ -1966,6 +1967,12 @@
                             break;
                     }
 
+                    assertNoDocTypeNotationEntityAncestor(sc, true);
+                    assertValidOffset(sc, so);
+
+                    assertNoDocTypeNotationEntityAncestor(ec, true);
+                    assertValidOffset(ec, eo);
+
                     boundaryUpdater(this, sc, so, ec, eo);
                 },
 
@@ -2128,6 +2135,12 @@
                     assertNoDocTypeNotationEntityAncestor(node, true);
                     assertValidOffset(node, offset);
                     this.setStartAndEnd(node, offset);
+                },
+
+                parentElement: function() {
+                    assertRangeValid(this);
+                    var parentNode = this.commonAncestorContainer;
+                    return parentNode ? getElementAncestor(this.commonAncestorContainer, true) : null;
                 }
             });
 
@@ -2149,17 +2162,11 @@
             range.endContainer = endContainer;
             range.endOffset = endOffset;
             range.document = dom.getDocument(startContainer);
-
             updateCollapsedAndCommonAncestor(range);
         }
 
         function Range(doc) {
-            this.startContainer = doc;
-            this.startOffset = 0;
-            this.endContainer = doc;
-            this.endOffset = 0;
-            this.document = doc;
-            updateCollapsedAndCommonAncestor(this);
+            updateBoundaries(this, doc, 0, doc, 0);
         }
 
         createPrototypeRange(Range, updateBoundaries);

--- a/lib/rangy-highlighter.js
+++ b/lib/rangy-highlighter.js
@@ -4,10 +4,10 @@
  *
  * Depends on Rangy core, ClassApplier and optionally TextRange modules.
  *
- * Copyright 2015, Tim Down
+ * Copyright 2016, Tim Down
  * Licensed under the MIT license.
  * Version: 1.3.1-dev
- * Build date: 20 May 2015
+ * Build date: 15 January 2016
  */
 (function(factory, root) {
     if (typeof define == "function" && define.amd) {
@@ -34,8 +34,16 @@
             return h1.characterRange.start - h2.characterRange.start;
         }
 
+        function getDocumentFromUnknownElement(doc){
+            return Object.prototype.toString.call(doc) == "[object HTMLDocument]" ? doc : doc.ownerDocument;
+        }
+
+        function getContainerElementId(doc){
+            return Object.prototype.toString.call(doc) != "[object HTMLDocument]" ? doc.getAttribute('id') : null;
+        }
+
         function getContainerElement(doc, id) {
-            return id ? doc.getElementById(id) : getBody(doc);
+            return id ? getDocumentFromUnknownElement(doc).getElementById(id) : getBody(doc);
         }
 
         /*----------------------------------------------------------------------------------------------------------------*/
@@ -330,7 +338,7 @@
                 var classApplier = className ? this.classAppliers[className] : null;
 
                 options = createOptions(options, {
-                    containerElementId: null,
+                    containerElementId: getContainerElementId(this.doc),
                     exclusive: true
                 });
 
@@ -339,7 +347,7 @@
 
                 var containerElement, containerElementRange, containerElementCharRange;
                 if (containerElementId) {
-                    containerElement = this.doc.getElementById(containerElementId);
+                    containerElement = getDocumentFromUnknownElement(this.doc).getElementById(containerElementId);
                     if (containerElement) {
                         containerElementRange = api.createRange(this.doc);
                         containerElementRange.selectNodeContents(containerElement);
@@ -431,7 +439,7 @@
                 var converter = this.converter;
 
                 options = createOptions(options, {
-                    containerElement: null,
+                    containerElement: this.doc,
                     exclusive: true
                 });
 
@@ -459,7 +467,7 @@
                 var classApplier = className ? this.classAppliers[className] : false;
 
                 options = createOptions(options, {
-                    containerElementId: null,
+                    containerElementId: getContainerElementId(this.doc),
                     exclusive: true
                 });
 

--- a/lib/rangy-selectionsaverestore.js
+++ b/lib/rangy-selectionsaverestore.js
@@ -7,10 +7,10 @@
  *
  * Depends on Rangy core.
  *
- * Copyright 2015, Tim Down
+ * Copyright 2016, Tim Down
  * Licensed under the MIT license.
  * Version: 1.3.1-dev
- * Build date: 20 May 2015
+ * Build date: 15 January 2016
  */
 (function(factory, root) {
     if (typeof define == "function" && define.amd) {
@@ -24,7 +24,7 @@
         factory(root.rangy);
     }
 })(function(rangy) {
-    rangy.createModule("SaveRestore", ["WrappedRange"], function(api, module) {
+    rangy.createModule("SaveRestore", ["WrappedSelection"], function(api, module) {
         var dom = api.dom;
         var removeNode = dom.removeNode;
         var isDirectionBackward = api.Selection.isDirectionBackward;

--- a/lib/rangy-serializer.js
+++ b/lib/rangy-serializer.js
@@ -8,10 +8,10 @@
  *
  * Depends on Rangy core.
  *
- * Copyright 2015, Tim Down
+ * Copyright 2016, Tim Down
  * Licensed under the MIT license.
  * Version: 1.3.1-dev
- * Build date: 20 May 2015
+ * Build date: 15 January 2016
  */
 (function(factory, root) {
     if (typeof define == "function" && define.amd) {

--- a/lib/rangy-textrange.js
+++ b/lib/rangy-textrange.js
@@ -24,10 +24,10 @@
  *
  * Depends on Rangy core.
  *
- * Copyright 2015, Tim Down
+ * Copyright 2016, Tim Down
  * Licensed under the MIT license.
  * Version: 1.3.1-dev
- * Build date: 20 May 2015
+ * Build date: 15 January 2016
  */
 
 /**

--- a/src/modules/rangy-highlighter.js
+++ b/src/modules/rangy-highlighter.js
@@ -23,8 +23,16 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
         return h1.characterRange.start - h2.characterRange.start;
     }
 
+    function getDocumentFromUnknownElement(doc){
+        return Object.prototype.toString.call(doc) == "[object HTMLDocument]" ? doc : doc.ownerDocument;
+    }
+
+    function getContainerElementId(doc){
+        return Object.prototype.toString.call(doc) != "[object HTMLDocument]" ? doc.getAttribute('id') : null;
+    }
+
     function getContainerElement(doc, id) {
-        return id ? doc.getElementById(id) : getBody(doc);
+        return id ? getDocumentFromUnknownElement(doc).getElementById(id) : getBody(doc);
     }
 
     /*----------------------------------------------------------------------------------------------------------------*/
@@ -319,7 +327,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
             var classApplier = className ? this.classAppliers[className] : null;
 
             options = createOptions(options, {
-                containerElementId: null,
+                containerElementId: getContainerElementId(this.doc),
                 exclusive: true
             });
 
@@ -328,7 +336,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
 
             var containerElement, containerElementRange, containerElementCharRange;
             if (containerElementId) {
-                containerElement = this.doc.getElementById(containerElementId);
+                containerElement = getDocumentFromUnknownElement(this.doc).getElementById(containerElementId);
                 if (containerElement) {
                     containerElementRange = api.createRange(this.doc);
                     containerElementRange.selectNodeContents(containerElement);
@@ -420,7 +428,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
             var converter = this.converter;
 
             options = createOptions(options, {
-                containerElement: null,
+                containerElement: this.doc,
                 exclusive: true
             });
 
@@ -448,7 +456,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
             var classApplier = className ? this.classAppliers[className] : false;
 
             options = createOptions(options, {
-                containerElementId: null,
+                containerElementId: getContainerElementId(this.doc),
                 exclusive: true
             });
 


### PR DESCRIPTION
Uses a DOM element as doc. This is more failsafe at HTML structure
changes.

Now you can specify a DOM object in which you have to highlight. Highlighter start counting just inside this DOM object and not from the beginning of the page. With TextRange and this feature you can safely highlight and store it for different devices even if you have separate menus for those.

We are using this initialization:
```
rangy.createHighlighter(document.getElementById("selectableTextContainer"),"TextRange");
```
