### PR TITLE
Do not create range with default document.

### DIFF
--- a/src/modules/rangy-textrange.js
+++ b/src/modules/rangy-textrange.js
@@ -1776,7 +1776,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
                 // Create a range representing the search scope if none was provided
                 var searchScopeRange = findOptions.withinRange;
                 if (!searchScopeRange) {
-                    searchScopeRange = api.createRange();
+                    searchScopeRange = api.createRange(this.getDocument());
                     searchScopeRange.selectNodeContents(this.getDocument());
                 }
 


### PR DESCRIPTION
Hi,

I stumbled upon this while using findText within an iframe, which happens in my mocha+phantomjs test setup. This is the error message:

``` 
  1) ...:
     Error: WRONG_DOCUMENT_ERR: DOM Exception 4
      at http://localhost:9000/app/bower_components/rangy/rangy-core.js:2304
      at updateNativeRange (http://localhost:9000/app/bower_components/rangy/rangy-core.js:2228)
      at http://localhost:9000/app/bower_components/rangy/rangy-core.js:1969
      at http://localhost:9000/app/bower_components/rangy/rangy-core.js:2360
      at http://localhost:9000/app/bower_components/rangy/rangy-textrange.js:1714
      at http://localhost:9000/app/bower_components/rangy/rangy-textrange.js:1514
```