### PR TITLE
TextRange module's findText fix for text with non-breaking space.

### DIFF
--- a/lib/rangy-textrange.js
+++ b/lib/rangy-textrange.js
@@ -1468,6 +1468,13 @@
                     currentChar = currentChar.toLowerCase();
                 }
 
+                // If there is a non-breaking space in the innerText, then replace with empty space " " so that it
+                // matches with the searchTerm. Based on the documentation, search should be performed on
+                // the visible text of the document
+                if (currentChar == "\u00a0") {
+                    currentChar = " ";
+                }
+
                 if (backward) {
                     chars.unshift(pos);
                     text = currentChar + text;

--- a/src/modules/rangy-textrange.js
+++ b/src/modules/rangy-textrange.js
@@ -1530,6 +1530,13 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
                 currentChar = currentChar.toLowerCase();
             }
 
+            // If there is a non-breaking space in the innerText, then replace with empty space " " so that it
+            // matches with the searchTerm. Based on the documentation, search should be performed on
+            // the visible text of the document
+            if (currentChar == "\u00a0") {
+                currentChar = " ";
+            }
+
             if (backward) {
                 chars.unshift(pos);
                 text = currentChar + text;


### PR DESCRIPTION
Added fix to the TextRange module's findText method to search and match the text when the text in the document contains non-breaking space (&nbsp;). 
For example, if the document has html "<span>test&nbsp;match with findText<span>", innerText would return "test match with findText". Even though the space looks normal whitespace between "test match", this is decoded character value of &nbsp;. When we search for "test match", textRange.findText wouldn't find match. 
According to the documentation, search should be performed on the visible text of the document but not on the decoded characters. Hence I made this change.

I'm trying to find proper way to run tests, once I figure out, I'll update the tests. If there is any documentation on how to run rangy tests, please provide. That would be helpful.