### PR TITLE
Workaround for IE

### DIFF
--- a/src/core/wrappedselection.js
+++ b/src/core/wrappedselection.js
@@ -170,6 +170,11 @@
                     if (chromeMatch && parseInt(chromeMatch[1]) >= 36) {
                         selectionSupportsMultipleRanges = false;
                     } else {
+                        // Internet Explorer 9-11 Workaround
+                        // Todo: Is this solution well?
+                        selectionSupportsMultipleRanges = false;
+                        // IE11 Bug - r2 is empty
+                        /*
                         var r2 = r1.cloneRange();
                         r1.setStart(textNode, 0);
                         r2.setEnd(textNode, 3);
@@ -177,6 +182,7 @@
                         sel.addRange(r1);
                         sel.addRange(r2);
                         selectionSupportsMultipleRanges = (sel.rangeCount == 2);
+                        */
                     }
                 }
 


### PR DESCRIPTION
IE11, Module 'WrappedSelection' failed to load: Unspecified error  - issue  https://github.com/timdown/rangy/issues/335

It's also been mentioned in the following stackoverflow post:
http://stackoverflow.com/questions/31899422/error-initializing-rangy-js-in-internet-explorer

Followings error seens during rangy initialization in textAngular

Module 'WrappedSelection' failed to load: Unspecified error.
Module 'SaveRestore' failed to load: Unable to get property 'isDirectionBackward' of undefined or null reference
TypeError: Unable to get property 'isDirectionBackward' of undefined or null reference