### PR TITLE
Add missing index declaration

### DIFF
--- a/lib/rangy-classapplier.js
+++ b/lib/rangy-classapplier.js
@@ -741,7 +741,7 @@
 
                 // Apply the merges
                 if (merges.length) {
-                    for (i = 0, len = merges.length; i < len; ++i) {
+                    for (let i = 0, len = merges.length; i < len; ++i) {
                         merges[i].doMerge(positionsToPreserve);
                     }
 


### PR DESCRIPTION
When using the postApply function from undoToRange() on multiple ranges this error occured :

```
ERROR ReferenceError: i is not defined
    at ClassApplier.postApply (rangy-classapplier.js:741)
    at ClassApplier.undoToRange (rangy-classapplier.js:976)
    at HighlighterDirective.undo (highlighter.directive.ts:52)
    at HighlighterDirective.set ranges [as ranges] (highlighter.directive.ts:19)
    at updateProp (core.js:32189)
    at checkAndUpdateDirectiveInline (core.js:31867)
    at checkAndUpdateNodeInline (core.js:44367)
    at checkAndUpdateNode (core.js:44306)
    at debugCheckAndUpdateNode (core.js:45328)
    at debugCheckDirectivesFn (core.js:45271)
```

This error is simply due to missing "let" in line 744. 

Thanks for your pretty good library ;)