### PR TITLE
Fix Prototype Pollution vulnerability (CVE-2023-26102) [security]

### DIFF
--- a/lib/rangy-core.js
+++ b/lib/rangy-core.js
@@ -158,6 +158,9 @@
         util.extend = extend = function(obj, props, deep) {
             var o, p;
             for (var i in props) {
+                if (i === "__proto__" || i === "constructor" || i === "prototype") {
+                    continue;
+                }
                 if (props.hasOwnProperty(i)) {
                     o = obj[i];
                     p = props[i];


### PR DESCRIPTION
fixes #481

Rangy was flagged with [Prototype Pollution vulnerability](https://security.snyk.io/vuln/SNYK-JS-RANGY-3175702) at the end of 2022. This PR proposes a solution by skipping the problematic object attributes in `rangy.util.extend()`